### PR TITLE
Public IP 표시 기능 및 --help 옵션 추가

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,10 +51,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -90,6 +108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +134,22 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -139,7 +182,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -159,10 +202,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -171,10 +234,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -266,10 +344,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hashbrown"
@@ -289,15 +397,210 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itertools"
@@ -324,10 +627,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -359,6 +678,12 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -401,8 +726,10 @@ dependencies = [
  "crossterm",
  "futures",
  "libc",
+ "once_cell",
  "ratatui",
  "rayon",
+ "reqwest",
  "rtnetlink",
  "thiserror 1.0.69",
  "tokio",
@@ -480,7 +807,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -493,6 +820,12 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking_lot"
@@ -524,6 +857,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +873,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -559,7 +907,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -599,7 +947,62 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -627,6 +1030,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +1077,66 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -688,6 +1182,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -705,6 +1209,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -743,6 +1253,44 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -786,18 +1334,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
+ "bytes",
  "io-uring",
  "libc",
  "mio 1.0.4",
  "pin-project-lite",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -812,6 +1371,60 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -843,10 +1456,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -896,6 +1629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1027,3 +1769,97 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ thiserror = "1.0"
 crossterm = "0.27"
 ratatui = "0.26"
 rayon = "1.10"  # For parallel processing
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }  # For HTTP requests with rustls
+once_cell = "1.19"  # For lazy static initialization
 
 # Platform-specific dependencies
 [target.'cfg(windows)'.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,11 +175,7 @@ fn run_simple_mode() -> Result<()> {
             }
 
             // 사설 IP가 있는 경우 Public IP도 표시
-            if iface
-                .ip_addresses
-                .iter()
-                .any(public_ip::is_private_ip)
-            {
+            if iface.ip_addresses.iter().any(public_ip::is_private_ip) {
                 print!("    Public IP: ");
                 if let Some(public_ip_addr) = public_ip::get_public_ip() {
                     println!("{}", public_ip_addr);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,10 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
 // 우리가 만든 라이브러리에서 필요한 구조체들을 import
-use nbmon::{network::{interface, public_ip}, App, ImprovedApp};
+use nbmon::{
+    network::{interface, public_ip},
+    App, ImprovedApp,
+};
 
 // fn main() -> Result<()>: 메인 함수
 // Result<()>는 성공시 (), 실패시 에러를 반환하는 타입
@@ -170,9 +173,13 @@ fn run_simple_mode() -> Result<()> {
                     println!("        - {} (Public)", ip);
                 }
             }
-            
+
             // 사설 IP가 있는 경우 Public IP도 표시
-            if iface.ip_addresses.iter().any(|ip| public_ip::is_private_ip(ip)) {
+            if iface
+                .ip_addresses
+                .iter()
+                .any(public_ip::is_private_ip)
+            {
                 print!("    Public IP: ");
                 if let Some(public_ip_addr) = public_ip::get_public_ip() {
                     println!("{}", public_ip_addr);
@@ -289,7 +296,10 @@ fn run_classic_tui() -> Result<()> {
 
 /// 도움말 메시지를 출력하는 함수
 fn show_help() {
-    println!("NBMon v{} - Cross-platform Network Bandwidth Monitor", env!("CARGO_PKG_VERSION"));
+    println!(
+        "NBMon v{} - Cross-platform Network Bandwidth Monitor",
+        env!("CARGO_PKG_VERSION")
+    );
     println!("Linux의 nload와 bmon에서 영감을 받은 실시간 네트워크 트래픽 모니터링 도구");
     println!();
     println!("사용법:");

--- a/src/network/linux_api.rs
+++ b/src/network/linux_api.rs
@@ -145,35 +145,32 @@ fn parse_proc_net_dev(
 /// IP 주소를 가져오는 함수 - ip 명령어를 사용
 fn get_ip_addresses(interface_name: &str) -> Result<Vec<IpAddr>> {
     let mut addresses = Vec::new();
-    
+
     // ip addr show 명령어 실행
     let output = Command::new("ip")
         .arg("addr")
         .arg("show")
         .arg(interface_name)
         .output();
-    
+
     let output = match output {
         Ok(o) => o,
         Err(_) => {
             // ip 명령어가 없는 경우 ifconfig 시도
-            if let Ok(o) = Command::new("ifconfig")
-                .arg(interface_name)
-                .output()
-            {
+            if let Ok(o) = Command::new("ifconfig").arg(interface_name).output() {
                 o
             } else {
                 return Ok(addresses); // 두 명령어 모두 실패하면 빈 배열 반환
             }
         }
     };
-    
+
     let stdout = String::from_utf8_lossy(&output.stdout);
-    
+
     // IP 주소 파싱 - inet 또는 inet6 라인 찾기
     for line in stdout.lines() {
         let line = line.trim();
-        
+
         // IPv4 주소 찾기 (inet 라인)
         if line.starts_with("inet ") {
             if let Some(addr_part) = line.split_whitespace().nth(1) {
@@ -198,6 +195,6 @@ fn get_ip_addresses(interface_name: &str) -> Result<Vec<IpAddr>> {
             }
         }
     }
-    
+
     Ok(addresses)
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -4,6 +4,7 @@
 // 공통 모듈들 (크로스플랫폼)
 pub mod interface; // 네트워크 인터페이스 정보 처리 (interface.rs)
 pub mod parallel_stats;
+pub mod public_ip; // Public IP 주소 조회 (public_ip.rs)
 pub mod stats; // 네트워크 통계 및 대역폭 계산 (stats.rs) // 병렬 통계 수집 (parallel_stats.rs)
 
 // 플랫폼별 API 모듈들 (조건부 컴파일)

--- a/src/network/public_ip.rs
+++ b/src/network/public_ip.rs
@@ -1,0 +1,166 @@
+// Public IP 주소를 가져오는 모듈
+// 외부 HTTP API를 사용하여 공인 IP 주소를 조회
+
+use anyhow::{Context, Result};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+// 캐시 구조체 - Public IP를 캐싱하여 과도한 API 호출 방지
+struct PublicIpCache {
+    ip: Option<String>,
+    last_updated: Option<Instant>,
+    cache_duration: Duration,
+}
+
+impl PublicIpCache {
+    fn new() -> Self {
+        Self {
+            ip: None,
+            last_updated: None,
+            cache_duration: Duration::from_secs(300), // 5분 캐시
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        if let Some(last_updated) = self.last_updated {
+            last_updated.elapsed() < self.cache_duration
+        } else {
+            false
+        }
+    }
+
+    fn get(&self) -> Option<String> {
+        if self.is_valid() {
+            self.ip.clone()
+        } else {
+            None
+        }
+    }
+
+    fn set(&mut self, ip: String) {
+        self.ip = Some(ip);
+        self.last_updated = Some(Instant::now());
+    }
+}
+
+// 전역 캐시 인스턴스
+static CACHE: Lazy<Mutex<PublicIpCache>> = Lazy::new(|| Mutex::new(PublicIpCache::new()));
+
+// Public IP 서비스 목록 (폴백 지원)
+const IP_SERVICES: &[&str] = &[
+    "https://api.ipify.org",           // 가장 간단하고 빠름
+    "https://checkip.amazonaws.com",   // AWS 제공, 신뢰성 높음
+    "https://ipinfo.io/ip",           // 추가 정보 제공 가능
+    "https://ifconfig.me/ip",         // 전통적인 서비스
+];
+
+/// Public IP 주소를 가져오는 함수
+/// 캐시된 값이 있으면 반환, 없으면 API 호출
+pub fn get_public_ip() -> Option<String> {
+    // 먼저 캐시 확인
+    {
+        let cache = CACHE.lock().unwrap();
+        if let Some(cached_ip) = cache.get() {
+            return Some(cached_ip);
+        }
+    }
+
+    // 캐시가 없거나 만료되었으면 새로 가져오기
+    if let Some(ip) = fetch_public_ip() {
+        let mut cache = CACHE.lock().unwrap();
+        cache.set(ip.clone());
+        Some(ip)
+    } else {
+        None
+    }
+}
+
+/// 실제로 외부 API를 호출하여 Public IP를 가져오는 함수
+fn fetch_public_ip() -> Option<String> {
+    // HTTP 클라이언트 생성 (타임아웃 설정)
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+        .ok()?;
+
+    // 각 서비스를 순차적으로 시도
+    for service_url in IP_SERVICES {
+        match try_fetch_from_service(&client, service_url) {
+            Ok(ip) => {
+                // 유효한 IP 주소인지 간단히 검증
+                if is_valid_ip(&ip) {
+                    return Some(ip);
+                }
+            }
+            Err(_) => continue, // 다음 서비스 시도
+        }
+    }
+
+    None
+}
+
+/// 특정 서비스에서 IP 주소를 가져오는 함수
+fn try_fetch_from_service(client: &reqwest::blocking::Client, url: &str) -> Result<String> {
+    let response = client
+        .get(url)
+        .send()
+        .context("Failed to send request")?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("HTTP request failed with status: {}", response.status());
+    }
+
+    let ip = response
+        .text()
+        .context("Failed to read response text")?
+        .trim()
+        .to_string();
+
+    Ok(ip)
+}
+
+/// IP 주소 문자열이 유효한지 간단히 검증하는 함수
+fn is_valid_ip(ip: &str) -> bool {
+    // IPv4 또는 IPv6 주소 형식인지 확인
+    ip.parse::<std::net::IpAddr>().is_ok()
+}
+
+/// 비동기 버전 - 백그라운드에서 Public IP 업데이트
+pub fn update_public_ip_async() {
+    std::thread::spawn(|| {
+        fetch_public_ip().and_then(|ip| {
+            let mut cache = CACHE.lock().unwrap();
+            cache.set(ip.clone());
+            Some(ip)
+        });
+    });
+}
+
+/// 캐시를 강제로 무효화하는 함수
+pub fn invalidate_cache() {
+    let mut cache = CACHE.lock().unwrap();
+    cache.ip = None;
+    cache.last_updated = None;
+}
+
+/// Private IP인지 확인하는 유틸리티 함수
+pub fn is_private_ip(ip: &std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(ipv4) => {
+            // RFC 1918 private ranges
+            let octets = ipv4.octets();
+            (octets[0] == 10)  // 10.0.0.0/8
+                || (octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31)  // 172.16.0.0/12
+                || (octets[0] == 192 && octets[1] == 168)  // 192.168.0.0/16
+                || (octets[0] == 127)  // 127.0.0.0/8 (loopback)
+        }
+        std::net::IpAddr::V6(ipv6) => {
+            // IPv6 private/local addresses
+            ipv6.is_loopback() 
+                || ipv6.is_unspecified()
+                || ipv6.segments()[0] & 0xfe00 == 0xfc00  // Unique local
+                || ipv6.segments()[0] & 0xffc0 == 0xfe80  // Link local
+        }
+    }
+}

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -239,12 +239,12 @@ impl App {
                     ),
                 ]));
             }
-            
+
             // IP 주소 표시 - Private과 Public 구분
             let ip_text = if let Some(local_ip) = interface.ip_addresses.first() {
                 let is_private = public_ip::is_private_ip(local_ip);
                 let local_str = local_ip.to_string();
-                
+
                 if is_private {
                     // 사설 IP인 경우 Public IP도 함께 표시
                     if let Some(public_ip) = public_ip::get_public_ip() {
@@ -256,14 +256,12 @@ impl App {
                     // 이미 공인 IP인 경우
                     local_str
                 }
+            } else if cfg!(unix) {
+                "None (install 'ip' or 'ifconfig')".to_string()
             } else {
-                if cfg!(unix) {
-                    "None (install 'ip' or 'ifconfig')".to_string()
-                } else {
-                    "None".to_string()
-                }
+                "None".to_string()
             };
-            
+
             lines.push(Line::from(vec![
                 Span::raw("IP: "),
                 Span::styled(ip_text, Style::default().fg(Color::Yellow)),

--- a/src/ui/app_improved.rs
+++ b/src/ui/app_improved.rs
@@ -265,17 +265,18 @@ impl ImprovedApp {
 
     fn update_stats(&mut self) -> Result<()> {
         // Public IP 업데이트 (5분마다 또는 처음)
-        let should_update_public_ip = self.last_public_ip_update
+        let should_update_public_ip = self
+            .last_public_ip_update
             .map(|last| last.elapsed() > Duration::from_secs(300))
             .unwrap_or(true);
-        
+
         if should_update_public_ip {
             if let Some(ip) = public_ip::get_public_ip() {
                 self.public_ip = Some(ip);
                 self.last_public_ip_update = Some(Instant::now());
             }
         }
-        
+
         // 개선된 에러 처리: 안전한 인덱스 접근
         let interface_idx = self.get_current_interface_index()?;
         let interface = &self.interfaces[interface_idx];
@@ -421,7 +422,7 @@ impl ImprovedApp {
         let ip_display = if let Some(local_ip) = interface.ip_addresses.first() {
             let is_private = public_ip::is_private_ip(local_ip);
             let local_str = local_ip.to_string();
-            
+
             if is_private {
                 // 사설 IP인 경우 Public IP도 함께 표시
                 if let Some(ref public_ip) = self.public_ip {
@@ -433,12 +434,10 @@ impl ImprovedApp {
                 // 이미 공인 IP인 경우
                 local_str
             }
+        } else if cfg!(unix) {
+            "None (install 'ip' or 'ifconfig')".to_string()
         } else {
-            if cfg!(unix) {
-                "None (install 'ip' or 'ifconfig')".to_string()
-            } else {
-                "None".to_string()
-            }
+            "None".to_string()
         };
 
         // Single line with all essential info


### PR DESCRIPTION
## Summary

이 PR에서는 사용자 경험 개선을 위한 두 가지 주요 기능을 추가합니다:

### 🌐 Public IP 표시 기능
- **사설 IP 환경 지원**: 공유기나 NAT 환경에서도 공인 IP 주소를 확인할 수 있습니다
- **지능형 IP 구분**: Private IP(10.x, 172.16-31.x, 192.168.x)와 Public IP를 자동으로 구분
- **다중 서비스 지원**: ipify, AWS, ipinfo.io 등 여러 서비스를 폴백으로 사용하여 안정성 향상
- **캐싱 최적화**: 5분 캐싱으로 불필요한 API 호출 방지

### 📖 명령행 도움말 개선
- **--help, -h**: 상세한 사용법, 키보드 단축키, 기능 설명
- **--version, -v**: 버전 정보 출력
- **한국어 지원**: 한국 사용자를 위한 친화적인 도움말

### 🔧 Linux IP 표시 개선
- **ip 명령어 지원**: `ip addr show` 명령어로 정확한 IP 주소 조회
- **ifconfig 폴백**: ip 명령어가 없을 때 ifconfig 사용
- **설치 안내**: 필요한 도구가 없을 때 설치 안내 메시지 표시

## 주요 변경사항

### 📁 새로운 파일
- `src/network/public_ip.rs`: Public IP 조회 및 캐싱 모듈

### 🔄 수정된 파일
- `Cargo.toml`: reqwest(rustls), once_cell 의존성 추가
- `src/main.rs`: --help, --version 옵션 및 Public IP 표시
- `src/network/linux_api.rs`: Linux IP 주소 조회 개선
- `src/ui/app.rs`, `src/ui/app_improved.rs`: UI에 Public IP 표시

## 테스트 결과

### ✅ 기본 기능 테스트
```bash
# 도움말 표시
cargo run -- --help
cargo run -- -h

# 버전 정보
cargo run -- --version
cargo run -- -v

# Public IP 표시 (Linux)
cargo run -- --simple
# 출력: 10.130.76.40 (Private) 
# 출력: Public IP: 106.249.245.178
```

### ✅ UI 모드별 테스트
- **향상된 TUI**: 사설 IP와 공인 IP 함께 표시됨
- **클래식 TUI**: IP 상세 정보에 Public IP 추가됨  
- **단순 모드**: Private/Public IP 구분하여 표시됨

## Test plan

- [x] Public IP 조회 기능 동작 확인
- [x] 사설 IP 자동 감지 테스트
- [x] 캐싱 기능 검증 (5분 간격)
- [x] 모든 UI 모드에서 Public IP 표시 확인
- [x] --help, --version 옵션 동작 확인
- [x] Linux에서 ip/ifconfig 명령어 폴백 테스트
- [x] 빌드 오류 없음 확인
- [x] 의존성 충돌 없음 확인

🤖 Generated with [Claude Code](https://claude.ai/code)